### PR TITLE
Changed @type for vocabulary to DefinedTerm

### DIFF
--- a/NDE_ComputationalTool.jsonld
+++ b/NDE_ComputationalTool.jsonld
@@ -94,7 +94,7 @@
           "infectiousAgent": {
             "description": "Infectious agent(s) / pathogen(s) which are the focus of the dataset or tool (e.g. SARS-CoV-2)",
             "oneOf": [{
-                "@type": "CreativeWork",
+                "@type": "DefinedTerm",
                 "description": "collection of vocabulary terms defined in ontologies",
                 "strict": false,
                 "type": "string",
@@ -110,7 +110,7 @@
               },
               {
                 "items": {
-                  "@type": "CreativeWork",
+                  "@type": "DefinedTerm",
                   "description": "collection of vocabulary terms defined in ontologies",
                   "strict": false,
                   "type": "string",
@@ -133,7 +133,7 @@
             "description": "The infectious disease(s) / health condition(s) which are the focus of the dataset or computational tool (e.g. COVID-19, coronavirus)",
             "oneOf": [{
               "items": {
-                "@type": "CreativeWork",
+                "@type": "DefinedTerm",
                 "description": "collection of vocabulary terms defined in ontologies",
                 "strict": false,
                 "type": "string",
@@ -200,7 +200,7 @@
             "description": "Species(es) from which dataset has been collected or for which the tool was designed or applied.",
             "oneOf": [{
               "items": {
-                "@type": "CreativeWork",
+                "@type": "DefinedTerm",
                 "description": "collection of vocabulary terms defined in ontologies",
                 "strict": false,
                 "type": "string",

--- a/NDE_Dataset.jsonld
+++ b/NDE_Dataset.jsonld
@@ -99,7 +99,7 @@
           "infectiousAgent": {
             "description": "Infectious agent(s) / pathogen(s) which are the focus of the dataset or tool (e.g. SARS-CoV-2)",
             "oneOf": [{
-                "@type": "CreativeWork",
+                "@type": "DefinedTerm",
                 "description": "collection of vocabulary terms defined in ontologies",
                 "strict": false,
                 "type": "string",
@@ -115,7 +115,7 @@
               },
               {
                 "items": {
-                  "@type": "CreativeWork",
+                  "@type": "DefinedTerm",
                   "description": "collection of vocabulary terms defined in ontologies",
                   "strict": false,
                   "type": "string",
@@ -137,7 +137,7 @@
           "healthCondition": {
             "description": "The infectious disease(s) / health condition(s) which are the focus of the dataset or computational tool (e.g. COVID-19, coronavirus)",
             "oneOf": [{
-                "@type": "CreativeWork",
+                "@type": "DefinedTerm",
                 "description": "collection of vocabulary terms defined in ontologies",
                 "strict": false,
                 "type": "string",
@@ -152,7 +152,7 @@
               },
               {
                 "items": {
-                  "@type": "CreativeWork",
+                  "@type": "DefinedTerm",
                   "description": "collection of vocabulary terms defined in ontologies",
                   "strict": false,
                   "type": "string",
@@ -313,7 +313,7 @@
           "species": {
             "description": "Species(es) from which dataset has been collected or for which the tool was designed or applied.",
             "oneOf": [{
-                "@type": "CreativeWork",
+                "@type": "DefinedTerm",
                 "description": "collection of vocabulary terms defined in ontologies",
                 "strict": false,
                 "type": "string",
@@ -329,7 +329,7 @@
               },
               {
                 "items": {
-                  "@type": "CreativeWork",
+                  "@type": "DefinedTerm",
                   "description": "collection of vocabulary terms defined in ontologies",
                   "strict": false,
                   "type": "string",
@@ -393,7 +393,7 @@
           "measurementTechnique": {
             "description": "A technique or technology used in a [[Dataset]] (or [[DataDownload]], [[DataCatalog]]),\ncorresponding to the method used for measuring the corresponding variable(s) (described using [[variableMeasured]]). This is oriented towards scientific and scholarly dataset publication but may have broader applicability; it is not intended as a full representation of measurement, but rather as a high level summary for dataset discovery.\n\nFor example, if [[variableMeasured]] is: molecule concentration, [[measurementTechnique]] could be: \"mass spectrometry\" or \"nmr spectroscopy\" or \"colorimetry\" or \"immunofluorescence\".\n\nIf the [[variableMeasured]] is \"depression rating\", the [[measurementTechnique]] could be \"Zung Scale\" or \"HAM-D\" or \"Beck Depression Inventory\".\n\nIf there are several [[variableMeasured]] properties recorded for some given data object, use a [[PropertyValue]] for each [[variableMeasured]] and attach the corresponding [[measurementTechnique]].\n      ",
             "oneOf": [{
-                "@type": "CreativeWork",
+                "@type": "DefinedTerm",
                 "description": "collection of vocabulary terms defined in ontologies",
                 "strict": false,
                 "type": "string",
@@ -410,7 +410,7 @@
               },
               {
                 "items": {
-                  "@type": "CreativeWork",
+                  "@type": "DefinedTerm",
                   "description": "collection of vocabulary terms defined in ontologies",
                   "strict": false,
                   "type": "string",


### PR DESCRIPTION
changed the `@type` for `healthCondition`, `infectiousAgent`, `species`, `measurementTechnique`, etc. from `CreativeWork` to `DefinedTerm` which has properties (`inDefinedTermSet` and `termCode`) which may be useful for ingested data complying to this schema.